### PR TITLE
Enable VS Code Java annotation processing to get rid of LSP errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
     },
   ],
   "java.test.defaultConfig": "WPIlibUnitTests",
-  "java.import.gradle.annotationProcessing.enabled": false,
+  "java.import.gradle.annotationProcessing.enabled": true,
   "java.completion.favoriteStaticMembers": [
     "org.junit.Assert.*",
     "org.junit.Assume.*",


### PR DESCRIPTION
This gets rid of an issue that crops up sometimes in VS Code where the code compiles fine but IntelliSense shows a ton of errors due to not being able to detect the generated AdvantageKit auto-logged inputs classes even though they existed in the build tree.  

The issue was seemingly that the VS Code setting to support annotation processing was set to `false` on a workspace level. I don't know exactly why this doesn't happen to everyone, but regardless it would probably be a good idea to fix so that other people aren't confused, since it's a fairly obscure setting.

Thanks!